### PR TITLE
Use cache then update from network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-3",
+  "version": "1.1.2-3-debug",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-3-debugger-3",
+  "version": "1.1.2-4",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-3-debug",
+  "version": "1.1.2-3-debugging-1",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-3-debugging-1",
+  "version": "1.1.2-3-debug-2",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-5",
+  "version": "1.1.2-3",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-3-debug-2",
+  "version": "1.1.2-3-debugger-3",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-service-worker",
   "description": "A Fusion.js plugin",
-  "version": "1.1.2-4",
+  "version": "1.1.2-5",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-service-worker",
   "main": "./dist/index.js",

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -52,6 +52,8 @@ export default function getHandlers(assetInfo: AssetInfo) {
               fetchNCache(event.request, expectsHtml);
             }
           }
+          // testing this: always replenish cache for next time
+          fetchNCache(event.request, expectsHtml);
           return cachedResponse;
         }
         return fetchNCache(event.request, expectsHtml);
@@ -80,7 +82,7 @@ function fetchNCache(request, expectsHtml) {
   const log = console;
   return fetch(request).then(resp => {
     log.log('*', 'resp.status', request.url, resp.status);
-    if (resp.status !== 200) {
+    if (resp.status !== 200 || resp.status !== 0) {
       return Promise.resolve(resp);
     }
     const clonedResponse = resp.clone();

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -73,7 +73,7 @@ function removeKeys(cache, keys) {
 }
 
 function fetchNCache(request, expectsHtml) {
-  return fetch(request, {mode: 'no-cors'}).then(resp => {
+  return fetch(request).then(resp => {
     debug.log(
       `[DEBUG] sw: request.url=${request.url}, resp.status=${resp.status}`
     );

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -77,11 +77,14 @@ function removeKeys(cache, keys) {
 }
 
 function fetchNCache(request, expectsHtml) {
+  const log = console;
   return fetch(request).then(resp => {
+    log.log('*', 'resp.status', request.url, resp.status);
     if (resp.status !== 200) {
       return Promise.resolve(resp);
     }
     const clonedResponse = resp.clone();
+    log.log('**', 'clonedResponse', request.url, clonedResponse);
     caches.open(cacheName).then(cache => {
       if (expectsHtml) {
         // check we got html before caching
@@ -89,7 +92,9 @@ function fetchNCache(request, expectsHtml) {
           return Promise.resolve(resp);
         }
       }
+      log.log('***', 'about to put cache', request.url);
       cache.put(request.url, clonedResponse);
+      log.log('****', 'put cache', request.url);
     });
     return Promise.resolve(resp);
   });

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@
 
 /* global */
 
+import url from 'url';
 import {createPlugin} from 'fusion-core';
 import type {FusionPlugin} from 'fusion-core';
 
@@ -9,6 +10,10 @@ import {SWTemplateFunctionToken} from './tokens';
 
 function invokeTemplateFn(templateFn, resources) {
   return templateFn(resources);
+}
+
+function hasSameHostName(url1, url2) {
+  return url.parse(String(url1)).hostname === url.parse(String(url2)).hostname;
 }
 
 export default ((__NODE__ &&
@@ -27,9 +32,12 @@ export default ((__NODE__ &&
               ctx.type = 'text/javascript';
               ctx.set('Cache-Control', 'max-age=0');
               ctx.body = invokeTemplateFn(templateFn, {
-                // TODO(#24): use correct values
-                precachePaths: chunkUrls,
+                // TODO(#24): also include images etc.
                 cacheablePaths: chunkUrls,
+                // cannot precache from different domain
+                precachePaths: chunkUrls.filter(url =>
+                  hasSameHostName(url, ctx.url)
+                ),
               });
             } catch (e) {
               // TODO(#25): do something maybe


### PR DESCRIPTION
This is an extra safety device, somewhat similar to Toobox's [fastest](https://github.com/GoogleChromeLabs/sw-toolbox/blob/master/docs/api.md#toolboxfastest) strategy.

If cache is present, use it. But asynchronously also update cache from network, so that cache is always recent. 